### PR TITLE
Fixed typo in healthcheck namespace

### DIFF
--- a/flux-system/kustomizations/kustomization-podinfo.yaml
+++ b/flux-system/kustomizations/kustomization-podinfo.yaml
@@ -16,4 +16,4 @@ spec:
     - apiVersion: apps/v1
       kind: Deployment
       name: podinfo
-      namespace: pofinfo
+      namespace: podinfo


### PR DESCRIPTION
Fixed a typo in the namespace used in the healthcheck
